### PR TITLE
Kill kex docker container on cancel button

### DIFF
--- a/src/main/kotlin/org/vorpal/research/kex/plugin/KexBackgroundable.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/KexBackgroundable.kt
@@ -32,10 +32,10 @@ class KexBackgroundable(project: Project, title: String,
                 try {
                     indicator.checkCanceled()
                     println("checkCanceled")
+                    Thread.sleep(1000)
                 } catch (pce: ProcessCanceledException) {
                     ProcessBuilder("docker", "kill", "123").start().waitFor()
                 }
-                Thread.sleep(1000)
             }
             println("Thread finished")
         }

--- a/src/main/kotlin/org/vorpal/research/kex/plugin/KexBaseAction.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/KexBaseAction.kt
@@ -43,9 +43,8 @@ abstract class KexBaseAction : AnAction() {
         toolWindow.contentManager.addContent(content)
         toolWindow.show()
 
-        val kexBackgroundTask = KexBackgroundable(project, TITLE)
-        kexBackgroundTask.command = dockerKexOptionArgs.list
-        kexBackgroundTask.consoleView = consoleView
+        val command = dockerKexOptionArgs.list
+        val kexBackgroundTask = KexBackgroundable(project, TITLE, command, consoleView)
 
         ProgressManager.getInstance().run(kexBackgroundTask)
     }

--- a/src/main/kotlin/org/vorpal/research/kex/plugin/util/DockerArgs.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/util/DockerArgs.kt
@@ -13,7 +13,7 @@ class DockerArgs(
         get() = getDockerArgs()
 
     private fun getDockerArgs(): List<String> {
-        val dockerArgs = mutableListOf("docker", "run", "--rm")
+        val dockerArgs = mutableListOf("docker", "run", "--rm", "--name", "123")
 
         // Bind dependencies
         for (i in localClasspathList.indices) {


### PR DESCRIPTION
Backround task is canceled (docker container is killed) when the "cancel" button in progress bar is clicked.
Close #2.