### PR TITLE
Fixes

### DIFF
--- a/src/main/kotlin/org/vorpal/research/kex/plugin/EditorAction.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/EditorAction.kt
@@ -1,6 +1,7 @@
 package org.vorpal.research.kex.plugin
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.module.ModuleUtil
 import org.vorpal.research.kex.plugin.util.psi.targetName
 
@@ -8,7 +9,7 @@ class EditorAction : KexBaseAction() {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val psiElement = EditorActionGroup.psiElement
+        val psiElement = e.getData(CommonDataKeys.PSI_ELEMENT) ?: return
         val module = ModuleUtil.findModuleForPsiElement(psiElement) ?: return
         val target = psiElement.targetName ?: return
 

--- a/src/main/kotlin/org/vorpal/research/kex/plugin/EditorActionGroup.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/EditorActionGroup.kt
@@ -4,26 +4,27 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.util.elementType
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFunction
 
 class EditorActionGroup : DefaultActionGroup() {
 
-    companion object {
-        lateinit var psiElement: PsiElement
-    }
-
     override fun update(e: AnActionEvent) {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE) ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
-        val psiElement = psiFile.viewProvider.findElementAt(editor.caretModel.offset)?.parent
-        if (psiElement != null) {
-            val isJavaElement = psiElement is PsiClass || psiElement is PsiMethod
-            val isKotlinElement = psiElement is KtClass || psiElement is KtFunction
-            e.presentation.isEnabledAndVisible = isJavaElement || isKotlinElement
-            EditorActionGroup.psiElement = psiElement
-        }
+
+        val psiElement = psiFile.viewProvider.findElementAt(editor.caretModel.offset)
+        val psiElementParent = psiElement?.parent
+
+        if (psiElement == null || psiElementParent == null) return
+
+        // Couldn't come up with something more elegant
+        val isIdentifierElement = psiElement.elementType?.debugName == "IDENTIFIER"
+        val isJavaParent = psiElementParent is PsiClass || psiElementParent is PsiMethod
+        val isKotlinParent = psiElementParent is KtClass || psiElementParent is KtFunction
+
+        e.presentation.isEnabledAndVisible = isIdentifierElement && (isJavaParent || isKotlinParent)
     }
 }

--- a/src/main/kotlin/org/vorpal/research/kex/plugin/KexBaseAction.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/KexBaseAction.kt
@@ -21,6 +21,8 @@ abstract class KexBaseAction : AnAction() {
         val buildResult = projectTaskManager.build(module)
 
         buildResult.onSuccess {
+            if (it.hasErrors()) return@onSuccess
+
             val classpathList = getModuleClasspathList(module)
             val testDirPath = getModuleTestDirPath(module)
 

--- a/src/main/kotlin/org/vorpal/research/kex/plugin/KexTaskManager.kt
+++ b/src/main/kotlin/org/vorpal/research/kex/plugin/KexTaskManager.kt
@@ -14,7 +14,7 @@ class KexTaskManager(private val project: Project) {
     fun showConsole() {
         val content = toolWindow.contentManager.factory.createContent(consoleView.component, "$TITLE Output", true)
         content.isCloseable = true
-        toolWindow.contentManager.addContent(content)
+        toolWindow.contentManager.addContent(content, 0)
         toolWindow.show()
     }
 


### PR DESCRIPTION
* Focus on new ConsoleView with Kex output
* Don't launch Kex if there are any build failures
* EditorActionGroup appears in context menu only for identifier in class or method declaration
